### PR TITLE
Hide quantization, adapters, and performance tabs for cloud models

### DIFF
--- a/src/flows/ViewModel/General/General.tsx
+++ b/src/flows/ViewModel/General/General.tsx
@@ -597,76 +597,78 @@ const General: React.FC<GeneralProps> = ({ data, goToAdapter }) => {
         )}
         <div className="hR"></div>
 
-        <div className="mt-[1.4rem] mb-[1.4rem]" ref={containerRef}>
-          <div
-            className="w-full mb-[1rem] py-[1.5rem] px-[1rem] cursor-pointer bg-[#101010] hover:bg-[#1F1F1F]  border border-[#1F1F1F] rounded-[8px]"
-            onClick={() =>
-              onDerivedCardClick({
-                name: "Quantizations",
-                value: `${data?.quantizations_count} models`,
-                color: "#B3B3B3",
-                key: "quantized",
-              })
-            }
-          >
-            <div className="flex justify-start align-center mb-[0.5rem]">
-              <Image
-                preview={false}
-                src={"/images/icons/modelRepoWhite.png"}
-                alt="info"
-                width={18}
-                height={18}
-              />
-              <Text_14_400_EEEEEE className="ml-[.5rem] mt-[-.1rem]">
-                Quantised Models
-              </Text_14_400_EEEEEE>
+        {data?.provider_type !== 'cloud_model' && (
+          <div className="mt-[1.4rem] mb-[1.4rem]" ref={containerRef}>
+            <div
+              className="w-full mb-[1rem] py-[1.5rem] px-[1rem] cursor-pointer bg-[#101010] hover:bg-[#1F1F1F]  border border-[#1F1F1F] rounded-[8px]"
+              onClick={() =>
+                onDerivedCardClick({
+                  name: "Quantizations",
+                  value: `${data?.quantizations_count} models`,
+                  color: "#B3B3B3",
+                  key: "quantized",
+                })
+              }
+            >
+              <div className="flex justify-start align-center mb-[0.5rem]">
+                <Image
+                  preview={false}
+                  src={"/images/icons/modelRepoWhite.png"}
+                  alt="info"
+                  width={18}
+                  height={18}
+                />
+                <Text_14_400_EEEEEE className="ml-[.5rem] mt-[-.1rem]">
+                  Quantised Models
+                </Text_14_400_EEEEEE>
+              </div>
+              <div className="flex justify-between items-center mt-[1rem]">
+                <span className="text-[2.375rem] text-[#EEEEEE] leading-[100%] font-[400] relative">
+                  {data?.quantizations_count}
+                </span>
+                <div
+                  className={`items-center align-center text-[0.75rem] px-[0.8rem] py-[.3rem] cursor-pointer bg-[#1F1F1F] hover:bg-[#101010] border border-[#757575] rounded-[8px] text-[#EEEEEE] hover:text-[#EEEEEE] flex mr-[.6rem] whitespace-nowrap`}
+                >
+                  See More <ChevronRight className="h-[0.8rem]" width={16} />
+                </div>
+              </div>
             </div>
-            <div className="flex justify-between items-center mt-[1rem]">
-              <span className="text-[2.375rem] text-[#EEEEEE] leading-[100%] font-[400] relative">
-                {data?.quantizations_count}
-              </span>
-              <div
-                className={`items-center align-center text-[0.75rem] px-[0.8rem] py-[.3rem] cursor-pointer bg-[#1F1F1F] hover:bg-[#101010] border border-[#757575] rounded-[8px] text-[#EEEEEE] hover:text-[#EEEEEE] flex mr-[.6rem] whitespace-nowrap`}
-              >
-                See More <ChevronRight className="h-[0.8rem]" width={16} />
+            <div
+              className="w-full py-[1.5rem] px-[1rem] cursor-pointer bg-[#101010] hover:bg-[#1F1F1F]  border border-[#1F1F1F] rounded-[8px]"
+              onClick={() =>
+                onDerivedCardClick({
+                  name: "Adapters",
+                  value: `${data?.quantizations_count} models`,
+                  color: "#B3B3B3",
+                  key: "adapter",
+                })
+              }
+            >
+              <div className="flex justify-start align-center mb-[0.5rem]">
+                <Image
+                  preview={false}
+                  src={"/images/icons/adapter.png"}
+                  alt="info"
+                  width={18}
+                  height={18}
+                />
+                <Text_14_400_EEEEEE className="ml-[.5rem] mt-[-.1rem]">
+                  Adapters
+                </Text_14_400_EEEEEE>
+              </div>
+              <div className="flex justify-between items-center mt-[1rem]">
+                <span className="text-[2.375rem] text-[#EEEEEE] leading-[100%] font-[400] relative">
+                  {data?.adapters_count}
+                </span>
+                <div
+                  className={`items-center align-center text-[0.75rem] px-[0.8rem] py-[.3rem] cursor-pointer bg-[#1F1F1F] hover:bg-[#101010] border border-[#757575] rounded-[8px] text-[#EEEEEE] hover:text-[#EEEEEE] flex mr-[.6rem] whitespace-nowrap`}
+                >
+                  See More <ChevronRight className="h-[0.8rem]" width={16} />
+                </div>
               </div>
             </div>
           </div>
-          <div
-            className="w-full py-[1.5rem] px-[1rem] cursor-pointer bg-[#101010] hover:bg-[#1F1F1F]  border border-[#1F1F1F] rounded-[8px]"
-            onClick={() =>
-              onDerivedCardClick({
-                name: "Adapters",
-                value: `${data?.quantizations_count} models`,
-                color: "#B3B3B3",
-                key: "adapter",
-              })
-            }
-          >
-            <div className="flex justify-start align-center mb-[0.5rem]">
-              <Image
-                preview={false}
-                src={"/images/icons/adapter.png"}
-                alt="info"
-                width={18}
-                height={18}
-              />
-              <Text_14_400_EEEEEE className="ml-[.5rem] mt-[-.1rem]">
-                Adapters
-              </Text_14_400_EEEEEE>
-            </div>
-            <div className="flex justify-between items-center mt-[1rem]">
-              <span className="text-[2.375rem] text-[#EEEEEE] leading-[100%] font-[400] relative">
-                {data?.adapters_count}
-              </span>
-              <div
-                className={`items-center align-center text-[0.75rem] px-[0.8rem] py-[.3rem] cursor-pointer bg-[#1F1F1F] hover:bg-[#101010] border border-[#757575] rounded-[8px] text-[#EEEEEE] hover:text-[#EEEEEE] flex mr-[.6rem] whitespace-nowrap`}
-              >
-                See More <ChevronRight className="h-[0.8rem]" width={16} />
-              </div>
-            </div>
-          </div>
-        </div>
+        )}
 
         {data?.examples?.length > 0 && (
           <>

--- a/src/flows/ViewModel/ViewModelDetails.tsx
+++ b/src/flows/ViewModel/ViewModelDetails.tsx
@@ -89,7 +89,7 @@ export default function ViewModel() {
 
   useEffect(() => {
     if (selectedModel?.provider_type === 'cloud_model') {
-      setFilteredItems(items.filter((item) => item.key !== '4'));
+      setFilteredItems(items.filter((item) => item.key !== '3' && item.key !== '4' && item.key !== '5'));
     } else {
       setFilteredItems(items); // Use all tabs
     }


### PR DESCRIPTION
## Summary
This PR hides quantization, adapters, and performance-related features from cloud models in the model detail drawer view.

## Changes Made

### 1. General Tab (`/src/flows/ViewModel/General/General.tsx`)
- Added condition to hide quantization and adapter cards for cloud models
- These sections now only display when `data?.provider_type \!== 'cloud_model'`

### 2. ViewModelDetails (`/src/flows/ViewModel/ViewModelDetails.tsx`)
- Updated tab filtering logic for cloud models to exclude:
  - Performance tab (key '3')
  - Advanced tab (key '4') 
  - Adapters tab (key '5')

## Result
**Cloud models** will now only show:
- General tab
- Evaluations tab

**Local models** will continue to show all tabs and features as before.

## Test plan
- [ ] Open a cloud model in the model detail drawer
- [ ] Verify only General and Evaluations tabs are visible
- [ ] Verify no quantization/adapter cards appear in General tab
- [ ] Open a local model in the model detail drawer
- [ ] Verify all tabs are visible (General, Evaluations, Performance, Advanced, Adapters)
- [ ] Verify quantization and adapter cards are displayed in General tab

🤖 Generated with [Claude Code](https://claude.ai/code)